### PR TITLE
Simplification of Exchange AddOrder and CancelOrder api: remove unused methods.

### DIFF
--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Abstractions/Exchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Abstractions/Exchange.cs
@@ -128,40 +128,6 @@ namespace TradingBot.Exchanges.Abstractions
             return Task.WhenAll(_acknowledgementsHandlers.Select(x => x.Handle(ack)));
         }
 
-        internal async Task<bool> AddOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            bool added = await AddOrderImpl(signal, translatedSignal);
-
-            await LykkeLog.WriteInfoAsync(nameof(Exchange), nameof(AddOrder), "", $"Signal {signal} added with result {added}");
-
-            return added;
-        }
-
-        protected virtual async Task<bool> AddOrderImpl(TradingSignal signal,
-            TranslatedSignalTableEntity translatedSignal)
-        {
-            ExecutedTrade trade = await AddOrderAndWaitExecution(signal, translatedSignal, _defaultTimeOut);
-
-            return trade != null && (
-                       trade.Status == ExecutionStatus.New ||
-                       trade.Status == ExecutionStatus.Fill ||
-                       trade.Status == ExecutionStatus.PartialFill ||
-                       trade.Status == ExecutionStatus.Pending);
-        }
-
-        internal Task<bool> CancelOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            return CancelOrderImpl(signal, translatedSignal);
-        }
-
-        protected virtual async Task<bool> CancelOrderImpl(TradingSignal signal,
-            TranslatedSignalTableEntity translatedSignal)
-        {
-            ExecutedTrade trade = await CancelOrderAndWaitExecution(signal, translatedSignal, _defaultTimeOut);
-
-            return trade != null && trade.Status == ExecutionStatus.Cancelled;
-        }
-
         public abstract Task<ExecutedTrade> AddOrderAndWaitExecution(TradingSignal signal,
             TranslatedSignalTableEntity translatedSignal,
             TimeSpan timeout);

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/HistoricalData/HistoricalDataExchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/HistoricalData/HistoricalDataExchange.cs
@@ -58,16 +58,6 @@ namespace TradingBot.Exchanges.Concrete.HistoricalData
             reader?.Dispose();
         }
 
-        protected override Task<bool> AddOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override Task<bool> CancelOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            throw new NotImplementedException();
-        }
-
         public override Task<ExecutedTrade> AddOrderAndWaitExecution(TradingSignal signal, TranslatedSignalTableEntity translatedSignal, TimeSpan timeout)
         {
             throw new NotImplementedException();

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmConnector.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmConnector.cs
@@ -565,7 +565,7 @@ namespace TradingBot.Exchanges.Concrete.Icm
             return Session.SendToTarget(request);
         }
 
-        public bool AddOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
+        private bool AddOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
         {
             if (!orderSignals.TryAdd(signal.OrderId, signal))
                 throw new InvalidOperationException($"Order with ID {signal.OrderId} was sent already");
@@ -682,7 +682,7 @@ namespace TradingBot.Exchanges.Concrete.Icm
             return result;
         }
 
-        public bool CancelOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
+        private bool CancelOrder(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
         {
             logger.WriteInfoAsync(nameof(IcmConnector), nameof(CancelOrder), string.Empty, $"Generating request for cancelling order {signal.OrderId} for {signal.Instrument.Name}").Wait();
 

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmExchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmExchange.cs
@@ -128,28 +128,6 @@ namespace TradingBot.Exchanges.Concrete.Icm
                     })
                 .Start();
         }
-        
-        protected override async Task<bool> AddOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            await LykkeLog.WriteInfoAsync(
-                nameof(Icm),
-                nameof(IcmExchange),
-                nameof(AddOrderImpl),
-                $"About to place new order for {signal}");
-            
-            return connector.AddOrder(signal, translatedSignal);
-        }
-
-        protected override async Task<bool> CancelOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            await LykkeLog.WriteInfoAsync(
-                nameof(Icm),
-                nameof(IcmExchange),
-                nameof(AddOrderImpl),
-                $"Canceling order {signal}");
-
-            return connector.CancelOrder(signal, translatedSignal);
-        }
 
         public override Task<ExecutedTrade> GetOrder(string orderId, Instrument instrument, TimeSpan timeout)
         {

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Kraken/KrakenExchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Kraken/KrakenExchange.cs
@@ -164,18 +164,6 @@ namespace TradingBot.Exchanges.Concrete.Kraken
                 });
         }
 
-
-        protected override async Task<bool> AddOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-        {
-            var executedTrade = await AddOrderAndWaitExecution(signal, translatedSignal, TimeSpan.FromSeconds(30));
-
-            if (executedTrade == null) return false;
-
-            translatedSignal.SetExecutionResult(executedTrade);
-
-            return true;
-        }
-
         public override async Task<ExecutedTrade> AddOrderAndWaitExecution(TradingSignal signal,
             TranslatedSignalTableEntity translatedSignal, TimeSpan timeout)
         {

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/StubImplementation/StubExchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/StubImplementation/StubExchange.cs
@@ -158,24 +158,6 @@ namespace TradingBot.Exchanges.Concrete.StubImplementation
 	        }
         }
 
-	    protected override Task<bool> AddOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-	    {
-	        translatedSignal.RequestSent("stub exchange don't send actual request");
-//
-//	        SimulateWork();
-//	        SimulateException();
-//	        
-		    translatedSignal.ResponseReceived("stub exchange don't recevie actual response");
-	        lock (syncRoot)
-	        {
-	            var s = new TradingSignal(signal.Instrument, Guid.NewGuid().ToString(), signal.Command, signal.TradeType, signal.Price, signal.Volume, signal.Time, signal.OrderType, signal.TimeInForce);
-	            ActualSignals[signal.Instrument.Name].AddLast(s);
-	            translatedSignal.ExternalId = s.OrderId;
-	        }
-
-		    return Task.FromResult(true);
-	    }
-
 	    private static readonly Random Random = new Random();
 	    private void SimulateException()
 	    {
@@ -190,38 +172,44 @@ namespace TradingBot.Exchanges.Concrete.StubImplementation
             Thread.Sleep(TimeSpan.FromSeconds(Random.Next(1, 11)));
         }
 
-	    protected override Task<bool> CancelOrderImpl(TradingSignal signal, TranslatedSignalTableEntity translatedSignal)
-	    {
-		    translatedSignal.RequestSent("stub exchange don't send actual request");
-//	        SimulateWork();
-//	        SimulateException();
-		    translatedSignal.ResponseReceived("stub exchange don't recevie actual response");
-
-	        bool isCanceled = false;
-	        lock (syncRoot)
-	        {
-	            TradingSignal existing = ActualSignals[signal.Instrument.Name].FirstOrDefault(x => x.OrderId == signal.OrderId);
-	            if (existing != null)
-	            {
-	                ActualSignals[signal.Instrument.Name].Remove(existing);
-	                isCanceled = true;
-	            }
-	        }
-	        
-		    return Task.FromResult(isCanceled);
-	    }
-
 	    public override Task<ExecutedTrade> AddOrderAndWaitExecution(TradingSignal signal, TranslatedSignalTableEntity translatedSignal, TimeSpan timeout)
 	    {
-		    throw new NotImplementedException();
+	        translatedSignal.RequestSent("stub exchange don't send actual request");
+//
+//	        SimulateWork();
+//	        SimulateException();
+//	        
+	        translatedSignal.ResponseReceived("stub exchange don't recevie actual response");
+	        lock (syncRoot)
+	        {
+	            var s = new TradingSignal(signal.Instrument, Guid.NewGuid().ToString(), signal.Command, signal.TradeType, signal.Price, signal.Volume, signal.Time, signal.OrderType, signal.TimeInForce);
+	            ActualSignals[signal.Instrument.Name].AddLast(s);
+	            translatedSignal.ExternalId = s.OrderId;
+	            
+	            return Task.FromResult(new ExecutedTrade(s.Instrument, DateTime.UtcNow, s.Price ?? 0, s.Volume, s.TradeType, s.OrderId, ExecutionStatus.New));
+	        }
 	    }
 
-        public override async Task<ExecutedTrade> CancelOrderAndWaitExecution(TradingSignal signal, TranslatedSignalTableEntity translatedSignal, TimeSpan timeout)
+        public override Task<ExecutedTrade> CancelOrderAndWaitExecution(TradingSignal signal, TranslatedSignalTableEntity translatedSignal, TimeSpan timeout)
         {
-            bool result = await CancelOrderImpl(signal, translatedSignal);
+            translatedSignal.RequestSent("stub exchange don't send actual request");
+//	        SimulateWork();
+//	        SimulateException();
+            translatedSignal.ResponseReceived("stub exchange don't recevie actual response");
 
-            return new ExecutedTrade(signal.Instrument, DateTime.UtcNow, signal.Price ?? 0, signal.Volume, signal.TradeType, signal.OrderId,
-                result ? ExecutionStatus.Cancelled : ExecutionStatus.Unknown);
+            bool isCanceled = false;
+            lock (syncRoot)
+            {
+                TradingSignal existing = ActualSignals[signal.Instrument.Name].FirstOrDefault(x => x.OrderId == signal.OrderId);
+                if (existing != null)
+                {
+                    ActualSignals[signal.Instrument.Name].Remove(existing);
+                    isCanceled = true;
+                }
+            }
+
+            return Task.FromResult(new ExecutedTrade(signal.Instrument, DateTime.UtcNow, signal.Price ?? 0, signal.Volume, signal.TradeType, signal.OrderId,
+                isCanceled ? ExecutionStatus.Cancelled : ExecutionStatus.Unknown));
         }
     }
 }


### PR DESCRIPTION
Remove Exchange's AddOrder(), AddOrderImpl(), CancelOrder() and CancelOrderImpl() methods as they not used anymore. There are AddOrderAndWaitExecution() and CancelOrderAndWaitExecution() left wich are used from both REST API and RabbitMQ messages.