### PR TITLE
Feature lwdev 5725 get tick prices

### DIFF
--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.AzureRepositories/OrderBooks/OrderBookRepository.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.AzureRepositories/OrderBooks/OrderBookRepository.cs
@@ -1,0 +1,100 @@
+﻿using AzureStorage;
+using Common;
+using Common.Log;
+using Lykke.Service.ExchangeDataStore.Core.Domain;
+using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Helpers;
+using Lykke.Service.ExchangeDataStore.Core.Settings.ServiceSettings;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.AzureRepositories.OrderBooks
+{
+    public class OrderBookRepository : IOrderBookRepository
+    {
+        private static readonly string _className = nameof(OrderBookRepository);
+
+        private readonly ILog _log;
+        private readonly INoSQLTableStorage<OrderBookSnapshotEntity> _tableStorage;
+        private readonly string _blobContainer;
+        private readonly IBlobStorage _blobStorage;
+
+        public OrderBookRepository(INoSQLTableStorage<OrderBookSnapshotEntity> tableStorage, IBlobStorage blobStorage, ILog log, AzureTableConfiguration dbConfig)
+        {
+            _tableStorage = tableStorage;
+            _blobStorage = blobStorage;
+            _log = log;
+            _blobContainer = dbConfig.EntitiesBlobContainerName;
+            
+        }
+
+        public async Task<List<OrderBook>> GetAsync(string exchangeName, string instrument, DateTime from, DateTime to, CancellationToken cancelToken)
+        {
+            await _log.WriteInfoAsync(_className, nameof(GetAsync), $"{exchangeName}, {instrument}, {from}, {to}");
+
+            var partitionKey = $"{exchangeName}_{instrument}".RemoveSpecialCharacters('-', '_', '.');
+          
+            var blobNames = (await _tableStorage.GetDataAsync(partitionKey, s => s.RowKey.ParseOrderbookTimestamp() >= from && s.RowKey.ParseOrderbookTimestamp() <= to)).Select(s => s.UniqueId).OrderBy(r => r).ToList();
+
+            var result = new ConcurrentBag<OrderBook>();
+            
+
+            //there is no way of downloading multiple blobs with a single request (e.g. batch download). So we try to download them in parallel with multiple simultaneous requests, each handling a batch of blobs.
+            Parallel.ForEach(blobNames, new ParallelOptions() { CancellationToken = cancelToken, MaxDegreeOfParallelism = Constants.MaxDegreeOfParallelismForBlobsDownload }, 
+            (blobName) =>
+            {
+                try
+                {
+                    cancelToken.ThrowIfCancellationRequested();
+
+                    var ordersStream = _blobStorage.GetAsync(_blobContainer, blobName).Result;
+                    var orders = ToListOfOrderBookItems(ordersStream.ToBytes());
+
+                    var asks = new ReadOnlyCollection<VolumePrice>(orders.Where(s => !s.IsBuy).Select(a => new VolumePrice(a.Price, a.Size)).ToList());
+                    var bids = new ReadOnlyCollection<VolumePrice>(orders.Where(s => s.IsBuy).Select(a => new VolumePrice(a.Price, a.Size)).ToList());
+
+                    Regex matchTimeStamp = new Regex(@"[0-9.T]+$");//extract orderbook timestamp from name
+                    var match = matchTimeStamp.Match(blobName);
+                    if (match.Success)
+                    {
+                        var orderBookTimestamp = DateTime.ParseExact(match.Value, Constants.OrderbookTimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+
+                        var orderBook = new OrderBook(exchangeName, instrument, asks, bids, orderBookTimestamp);
+                        result.Add(orderBook);
+                    }
+                    else
+                    {
+                        throw new ApplicationException($"Can not extract timestamp from blob name {blobName}.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _log.WriteWarningAsync(_className, blobName, ex.Message);
+                }
+            });
+
+            await _log.WriteInfoAsync(_className, nameof(GetAsync), $"{result.Count} results found for {exchangeName}, {instrument}, {from}, {to}");
+            return result.ToList();
+        }
+
+        private static readonly JsonSerializerSettings DeserializeSettings = new JsonSerializerSettings
+        {
+            DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
+        };
+
+        private List<OrderBookItem> ToListOfOrderBookItems(byte[] data)
+        {
+            return JsonConvert.DeserializeObject<List<OrderBookItem>>(Encoding.UTF8.GetString(data), DeserializeSettings);
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Constants.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Constants.cs
@@ -3,6 +3,8 @@
     public static class Constants
     {
         public const string JsonSerializationTimestampFormat = "yyyy-MM-ddTHH:mm:ss.fff";
-        public const string OrderbookTimestampFormat = "yyyyMMddTHHmmss.fff";     
+        public const string OrderbookTimestampFormat = "yyyyMMddTHHmmss.fff";
+        public const int MaxDegreeOfParallelismForBlobsDownload = 15;
+        public const int BlobStorageTimeOutSeconds = 400;
     }
 }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/OrderBooks/IOrderBookRepository.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/OrderBooks/IOrderBookRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks
+{
+    public interface IOrderBookRepository
+    {
+        Task<List<OrderBook>> GetAsync(string exchangeName, string instrument, DateTime from, DateTime to, CancellationToken cancelToken);
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Ticks/Instrument.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Ticks/Instrument.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json;
+
+namespace Lykke.Service.ExchangeDataStore.Core.Domain.Ticks
+{
+    public class Instrument
+    {
+        [JsonConstructor]
+        public Instrument(string exchange, string name)
+        {
+            Name = name;
+            Exchange = exchange;
+
+            if (name.Length == 6)
+            {
+                Base = name.Substring(0, 3);
+                Quote = name.Substring(3, 3);    
+            }
+            else if (name.StartsWith("LKK1Y"))
+            {
+                Base = "LKK1Y";
+                Quote = name.Remove(0, 5);
+            }
+            else if (name.EndsWith("LKK1Y"))
+            {
+                Base = name.Substring(0, name.Length - 5);
+                Quote = "LKK1Y";
+            }
+        }
+
+        public Instrument(string exchange, string name, string @base, string quote) : this(exchange, name)
+        {
+            Base = @base;
+            Quote = quote;
+        }
+
+        public string Name { get; }
+        
+        public string Exchange { get; }
+        
+        public string Base { get; }
+        
+        public string Quote { get; }
+        
+        public override string ToString()
+        {
+            return $"{Name} on {Exchange}";
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode() ^ Exchange.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return ((obj as Instrument)?.Name.Equals(Name) ?? false)
+                   && ((Instrument) obj).Exchange.Equals(Exchange);
+        }
+        
+        public static bool operator== (Instrument left, Instrument right) 
+        {
+            if ((object)left == (object)right) return true;
+            if ((object)left == null || (object)right == null) return false;
+            
+            return left.Exchange == right.Exchange && left.Name == right.Name;
+        }
+
+        public static bool operator !=(Instrument left, Instrument right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Ticks/TickPrice.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Domain/Ticks/TickPrice.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Lykke.Service.ExchangeDataStore.Core.Domain.Ticks
+{
+    public class TickPrice
+	{
+		[JsonConstructor]
+		public TickPrice(Instrument instrument, DateTime time, decimal ask, decimal bid)
+		{
+		    Instrument = instrument;
+		    
+			Time = time;
+			Ask = ask;
+			Bid = bid;
+		    
+		    Mid = (ask + bid) / 2m;
+		}
+
+	    public Instrument Instrument { get; }
+	    
+		public DateTime Time { get; }
+
+		public decimal Ask { get; }
+
+		public decimal Bid { get; }
+
+		[JsonIgnore]
+		public decimal Mid { get; }
+
+		public override string ToString()
+		{
+			return $"TickPrice for {Instrument}: Time={Time}, Ask={Ask}, Bid={Bid}, Mid={Mid}";
+		}
+	}
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Helpers/StringExtensions.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Helpers/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿using Lykke.Service.ExchangeDataStore.Core.Domain;
+using System;
+using System.Globalization;
+using System.Linq;
 
 namespace Lykke.Service.ExchangeDataStore.Core.Helpers
 {
@@ -8,6 +11,11 @@ namespace Lykke.Service.ExchangeDataStore.Core.Helpers
         {
             return new string(str.Where(c => char.IsLetterOrDigit(c) ||
                                              additionalCharsAllowed.Contains(c)).ToArray());
+        }
+
+        public static DateTime ParseOrderbookTimestamp(this string str)
+        {
+            return DateTime.ParseExact(str.Substring(0, 19), Constants.OrderbookTimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         }
     }
 }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Lykke.Service.ExchangeDataStore.Core.csproj
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Lykke.Service.ExchangeDataStore.Core.csproj
@@ -11,8 +11,4 @@
     <PackageReference Include="Lykke.Common" Version="4.4.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Services\DataHarvesters\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Services/OrderBooks/IOrderBookService.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Services/OrderBooks/IOrderBookService.cs
@@ -1,4 +1,5 @@
 ﻿using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Domain.Ticks;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -8,5 +9,6 @@ namespace Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks
     public interface IOrderBookService
     {
         Task<List<OrderBook>> GetAsync(string exchangeName, string instrument, DateTime from, DateTime to);
+        Task<List<TickPrice>> GetTickPricesAsync(string exchangeName, string instrument, DateTime from, DateTime to);
     }
 }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Services/OrderBooks/IOrderBookService.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Core/Services/OrderBooks/IOrderBookService.cs
@@ -1,0 +1,12 @@
+﻿using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks
+{
+    public interface IOrderBookService
+    {
+        Task<List<OrderBook>> GetAsync(string exchangeName, string instrument, DateTime from, DateTime to);
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
@@ -1,8 +1,11 @@
 ﻿using Lykke.Service.ExchangeDataStore.Core.Domain;
 using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Domain.Ticks;
 using Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks;
+using MoreLinq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,6 +27,47 @@ namespace Lykke.Service.ExchangeDataStore.Services.Domain
         {
             var result = await _orderBookRepo.GetAsync(exchangeName, instrument, from, to, _cancellationSource.Token);
             return result;
+        }
+
+        public async Task<List<TickPrice>> GetTickPricesAsync(string exchangeName, string instrument, DateTime from, DateTime to)
+        {
+            var orderBooks = (await _orderBookRepo.GetAsync(exchangeName, instrument, from, to, _cancellationSource.Token)).OrderBy(o=>o.Timestamp);
+
+            var result = new List<TickPrice>();
+
+            orderBooks.ForEach(orderBook =>
+            {
+                var lowestAsk = GetLowestAsk(orderBook);
+                var highestBid = GetHighestBid(orderBook);
+
+                var latestTick = GetCurrentLatestTickPrice(result);
+
+                if (!result.Any() || IsBidOrAskDifferentInLatestTick(latestTick, lowestAsk, highestBid))
+                {
+                    result.Add(new TickPrice(new Instrument(exchangeName, instrument), orderBook.Timestamp, lowestAsk, highestBid));
+                }
+            });
+
+            return result;
+        }
+
+        private bool IsBidOrAskDifferentInLatestTick(TickPrice currentLatestTick, decimal lowestAsk, decimal highestBid)
+        {
+            return currentLatestTick?.Ask != lowestAsk || currentLatestTick?.Bid != highestBid;
+        }
+
+        private TickPrice GetCurrentLatestTickPrice(List<TickPrice> result)
+        {
+            return result.Any() ? result.MaxBy(r => r.Time.Ticks) : null;
+        }
+
+        private decimal GetLowestAsk(OrderBook orderBook)
+        {
+            return orderBook.Asks.Any() ? orderBook.Asks.Min(a => a.Price) : 0;
+        }
+        private decimal GetHighestBid(OrderBook orderBook)
+        {
+            return orderBook.Bids.Any() ? orderBook.Bids.Max(a => a.Price) : 0;
         }
 
         public void Dispose()

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
@@ -1,0 +1,35 @@
+﻿using Lykke.Service.ExchangeDataStore.Core.Domain;
+using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.Services.Domain
+{
+    // ReSharper disable once ClassNeverInstantiated.Global - Autofac instantiated
+    public class OrderBookService : IOrderBookService, IDisposable
+    {
+        private readonly IOrderBookRepository _orderBookRepo;
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public OrderBookService(IOrderBookRepository orderBookRepo)
+        {
+            _orderBookRepo = orderBookRepo;
+            _cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(Constants.BlobStorageTimeOutSeconds));
+        }
+
+        public async Task<List<OrderBook>> GetAsync(string exchangeName, string instrument, DateTime from, DateTime to)
+        {
+            var result = await _orderBookRepo.GetAsync(exchangeName, instrument, from, to, _cancellationSource.Token);
+            return result;
+        }
+
+        public void Dispose()
+        {
+            _cancellationSource?.Cancel();
+            _cancellationSource?.Dispose();
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.Services/Domain/OrderBookService.cs
@@ -34,6 +34,7 @@ namespace Lykke.Service.ExchangeDataStore.Services.Domain
             var orderBooks = (await _orderBookRepo.GetAsync(exchangeName, instrument, from, to, _cancellationSource.Token)).OrderBy(o=>o.Timestamp);
 
             var result = new List<TickPrice>();
+            var tickInstrument = new Instrument(exchangeName, instrument);
 
             orderBooks.ForEach(orderBook =>
             {
@@ -44,7 +45,7 @@ namespace Lykke.Service.ExchangeDataStore.Services.Domain
 
                 if (!result.Any() || IsBidOrAskDifferentInLatestTick(latestTick, lowestAsk, highestBid))
                 {
-                    result.Add(new TickPrice(new Instrument(exchangeName, instrument), orderBook.Timestamp, lowestAsk, highestBid));
+                    result.Add(new TickPrice(tickInstrument, orderBook.Timestamp, lowestAsk, highestBid));
                 }
             });
 

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/BaseApiController.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/BaseApiController.cs
@@ -1,0 +1,32 @@
+﻿using Common;
+using Common.Log;
+using Lykke.Service.ExchangeDataStore.Extensions;
+using Lykke.Service.ExchangeDataStore.Infrastructure.Logging;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.Controllers.Api
+{
+    [Route("api/v1/[controller]")]
+    [Produces("application/json")]
+    [LoggingAspNetFilter]
+    public class BaseApiController : Controller
+    {
+        private readonly ILog _log;
+        private string TECHNICAL_ERROR_MESSAGE = "Error while processing request.";
+        public static string BaseApiUrl = "api/v1";
+
+        public BaseApiController(ILog log)
+        {
+            _log = log;
+        }
+
+        protected async Task<ObjectResult> LogAndReturnInternalServerError<T>(T callParams, ControllerContext controllerCtx, Exception ex)
+        {
+            await _log.WriteErrorAsync($"{BaseApiUrl}/{controllerCtx.GetControllerAndAction()}", new { callParams }.ToJson(), ex);
+            return StatusCode((int)HttpStatusCode.InternalServerError, TECHNICAL_ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/OrderBooksController.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/OrderBooksController.cs
@@ -1,0 +1,50 @@
+﻿using Common.Log;
+using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Models.Requests;
+using Lykke.Service.ExchangeDataStore.Models.ValidationModels;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Lykke.Service.ExchangeDataStore.Controllers.Api
+{
+    [ValidateModel]
+    public class OrderBooksController : BaseApiController
+    {
+        private readonly IOrderBookService _orderBookService;
+        private readonly ILog _log;
+        public OrderBooksController(IOrderBookService orderBookService, ILog log) : base(log)
+        {
+            _orderBookService = orderBookService;
+            _log = log;
+        }
+
+        /// <summary>
+        /// Get list of order books
+        /// <param name="request">The name of the exchange and instrument symbol</param>
+        /// <param name="dateTimeFrom">Period from</param>
+        /// <param name="dateTimeTo">Period to</param>
+        /// </summary>
+        [SwaggerOperation("GetOrderBooks")]
+        [HttpGet("{exchangeName}/{instrument}")]
+        [ProducesResponseType(typeof(IEnumerable<OrderBook>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.InternalServerError)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> Get(GetOrderBooksRequest request, [FromQuery]DateTime dateTimeFrom, [FromQuery]DateTime? dateTimeTo = null)
+        {
+            try
+            {
+                return Ok(await _orderBookService.GetAsync(request.ExchangeName, request.Instrument, dateTimeFrom, dateTimeTo ?? DateTime.UtcNow));
+            }
+            catch (Exception ex)
+            {
+                return await LogAndReturnInternalServerError($"{request.ExchangeName}, {request.Instrument}, {dateTimeFrom}, {dateTimeTo}", ControllerContext, ex);
+            }
+        }
+
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/TicksController.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Controllers/Api/TicksController.cs
@@ -1,5 +1,5 @@
 ﻿using Common.Log;
-using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
+using Lykke.Service.ExchangeDataStore.Core.Domain.Ticks;
 using Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks;
 using Lykke.Service.ExchangeDataStore.Models.Requests;
 using Lykke.Service.ExchangeDataStore.Models.ValidationModels;
@@ -13,38 +13,40 @@ using System.Threading.Tasks;
 namespace Lykke.Service.ExchangeDataStore.Controllers.Api
 {
     [ValidateModel]
-    public class OrderBooksController : BaseApiController
+    public class TicksController : BaseApiController
     {
         private readonly IOrderBookService _orderBookService;
         private readonly ILog _log;
-        public OrderBooksController(IOrderBookService orderBookService, ILog log) : base(log)
+        public TicksController(IOrderBookService orderBookService, ILog log) : base(log)
         {
             _orderBookService = orderBookService;
             _log = log;
         }
 
         /// <summary>
-        /// Get list of order books
+        /// Get ticks
         /// <param name="request">The name of the exchange and instrument symbol</param>
         /// <param name="dateTimeFrom">Period from</param>
         /// <param name="dateTimeTo">Period to</param>
         /// </summary>
-        [SwaggerOperation("GetOrderBooks")]
+        [SwaggerOperation("GetTickPrices")]
         [HttpGet("{exchangeName}/{instrument}")]
-        [ProducesResponseType(typeof(IEnumerable<OrderBook>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(IEnumerable<TickPrice>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.InternalServerError)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.BadRequest)]
-        public async Task<IActionResult> Get(OrderBookRequest request, [FromQuery]DateTime dateTimeFrom, [FromQuery]DateTime? dateTimeTo = null)
+        public async Task<IActionResult> Get(OrderBookRequest request,  [FromQuery]DateTime dateTimeFrom, [FromQuery]DateTime? dateTimeTo = null)
         {
             try
             {
-                return Ok(await _orderBookService.GetAsync(request.ExchangeName, request.Instrument, dateTimeFrom, dateTimeTo ?? DateTime.UtcNow));
+                return Ok(await _orderBookService.GetTickPricesAsync(request.ExchangeName, request.Instrument, dateTimeFrom, dateTimeTo ?? DateTime.UtcNow));
             }
             catch (Exception ex)
             {
                 return await LogAndReturnInternalServerError($"{request.ExchangeName}, {request.Instrument}, {dateTimeFrom}, {dateTimeTo}", ControllerContext, ex);
             }
         }
+
+        
 
     }
 }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Extensions/ControllerExtensions.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Extensions/ControllerExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Lykke.Service.ExchangeDataStore.Extensions
+{
+    public static class ControllerExtensions
+    {
+        public static string GetControllerAndAction(this ControllerContext contContext)
+        {
+            return $"{contContext.RouteData.Values["controller"].ToString()}/{contContext.RouteData.Values["action"].ToString()}";
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Infrastructure/Logging/Logging.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Infrastructure/Logging/Logging.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Lykke.Service.ExchangeDataStore.Infrastructure.Logging
+{
+    public static class Logging
+    {
+        public static ILoggerFactory LoggerFactory { get; } = new LoggerFactory().AddConsole(LogLevel.Debug);
+
+        public static ILogger CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Infrastructure/Logging/LoggingAspNetFilter.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Infrastructure/Logging/LoggingAspNetFilter.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace Lykke.Service.ExchangeDataStore.Infrastructure.Logging
+{
+    public class LoggingAspNetFilter : ActionFilterAttribute
+    {
+        private readonly ILogger _logger = Logging.CreateLogger<LoggingAspNetFilter>();
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            _logger.LogInformation($"Action {context.ActionDescriptor.DisplayName} executing on controller {context.Controller.GetType()}, query string: {context.HttpContext.Request.Path}{context.HttpContext.Request.QueryString}");
+            
+            base.OnActionExecuting(context);
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            _logger.LogInformation($"Action {context.ActionDescriptor.DisplayName} executed on controller {context.Controller.GetType()}");
+            
+            base.OnActionExecuted(context);
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.csproj
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.4.0" />
     <PackageReference Include="Lykke.Common" Version="4.4.2" />
     <PackageReference Include="Lykke.Common.ApiLibrary" Version="1.3.1" />
     <PackageReference Include="Lykke.Logs" Version="3.6.0" />

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/Requests/GetOrderBooksRequest.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/Requests/GetOrderBooksRequest.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Lykke.Service.ExchangeDataStore.Models.Requests
+{
+    public class GetOrderBooksRequest
+    {
+        [FromRoute]
+        public string ExchangeName { get; set; }
+        [FromRoute]
+        public string Instrument { get; set; }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/Requests/OrderBookRequest.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/Requests/OrderBookRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Lykke.Service.ExchangeDataStore.Models.Requests
 {
-    public class GetOrderBooksRequest
+    public class OrderBookRequest
     {
         [FromRoute]
         public string ExchangeName { get; set; }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/GetOrderBooksRequestValidationModel.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/GetOrderBooksRequestValidationModel.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation;
+using Lykke.Service.ExchangeDataStore.Models.Requests;
+
+namespace Lykke.Service.ExchangeDataStore.Models.ValidationModels
+{
+    // ReSharper disable once UnusedMember.Global - auto invoked by the framework
+    public class GetOrderBooksRequestValidationModel : AbstractValidator<GetOrderBooksRequest>
+    {
+        public GetOrderBooksRequestValidationModel()
+        {
+            RuleFor(r => r.ExchangeName).NotEmpty().WithMessage($"Invalid exchange name.");
+            RuleFor(r => r.Instrument).NotEmpty().WithMessage($"Invalid instrument name.");
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/GetOrderBooksRequestValidationModel.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/GetOrderBooksRequestValidationModel.cs
@@ -4,7 +4,7 @@ using Lykke.Service.ExchangeDataStore.Models.Requests;
 namespace Lykke.Service.ExchangeDataStore.Models.ValidationModels
 {
     // ReSharper disable once UnusedMember.Global - auto invoked by the framework
-    public class GetOrderBooksRequestValidationModel : AbstractValidator<GetOrderBooksRequest>
+    public class GetOrderBooksRequestValidationModel : AbstractValidator<OrderBookRequest>
     {
         public GetOrderBooksRequestValidationModel()
         {

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/ValidateModelAttribute.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Models/ValidationModels/ValidateModelAttribute.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Lykke.Service.ExchangeDataStore.Models.ValidationModels
+{
+    public class ValidateModelAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!context.ModelState.IsValid)
+            {
+                context.Result = new BadRequestObjectResult(context.ModelState);
+            }
+        }
+    }
+}

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Modules/ServiceModule.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Modules/ServiceModule.cs
@@ -6,10 +6,12 @@ using Common.Log;
 using Lykke.Service.ExchangeDataStore.AzureRepositories.OrderBooks;
 using Lykke.Service.ExchangeDataStore.Core.Domain.OrderBooks;
 using Lykke.Service.ExchangeDataStore.Core.Services;
+using Lykke.Service.ExchangeDataStore.Core.Services.OrderBooks;
 using Lykke.Service.ExchangeDataStore.Core.Settings.ServiceSettings;
 using Lykke.Service.ExchangeDataStore.Services;
 using Lykke.Service.ExchangeDataStore.Services.DataHarvesters;
 using Lykke.Service.ExchangeDataStore.Services.DataPersisters;
+using Lykke.Service.ExchangeDataStore.Services.Domain;
 using Lykke.SettingsReader;
 
 namespace Lykke.Service.ExchangeDataStore.Modules
@@ -29,7 +31,7 @@ namespace Lykke.Service.ExchangeDataStore.Modules
         {
             BindAzureRepositories(builder);
             RegisterLocalTypes(builder);
-            
+            RegisterLocalServices(builder);
         }
 
         private void RegisterLocalTypes(ContainerBuilder builder)
@@ -53,7 +55,13 @@ namespace Lykke.Service.ExchangeDataStore.Modules
                 _settings.ConnectionString(i => i.AzureStorage.EntitiesConnString), _settings.CurrentValue.AzureStorage.EntitiesTableName, _log);
             container.RegisterInstance(orderBookSnapshotStorage).As<INoSQLTableStorage<OrderBookSnapshotEntity>>().SingleInstance();
 
+            container.RegisterType<OrderBookRepository>().As<IOrderBookRepository>();
             container.RegisterType<OrderBookSnapshotsRepository>().As<IOrderBookSnapshotsRepository>();
+        }
+
+        private void RegisterLocalServices(ContainerBuilder builder)
+        {
+            builder.RegisterType<OrderBookService>().As<IOrderBookService>();
         }
     }
 }

--- a/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Startup.cs
+++ b/src/Lykke.Service.ExchangeDataStore/Lykke.Service.ExchangeDataStore/Startup.cs
@@ -2,11 +2,13 @@
 using Autofac.Extensions.DependencyInjection;
 using AzureStorage.Tables;
 using Common.Log;
+using FluentValidation.AspNetCore;
 using Lykke.Common.ApiLibrary.Middleware;
 using Lykke.Common.ApiLibrary.Swagger;
 using Lykke.Logs;
 using Lykke.Service.ExchangeDataStore.Core.Services;
 using Lykke.Service.ExchangeDataStore.Core.Settings;
+using Lykke.Service.ExchangeDataStore.Models.ValidationModels;
 using Lykke.Service.ExchangeDataStore.Modules;
 using Lykke.SettingsReader;
 using Lykke.SlackNotification.AzureQueue;
@@ -16,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
+
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
@@ -44,11 +47,15 @@ namespace Lykke.Service.ExchangeDataStore
         {
             try
             {
-                services.AddMvc()
+                services.AddMvc(options =>
+                    {
+                        options.Filters.Add<ValidateModelAttribute>();
+                    })
+                    .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>())
                     .AddJsonOptions(options =>
                     {
                         options.SerializerSettings.ContractResolver =
-                            new Newtonsoft.Json.Serialization.DefaultContractResolver();
+                        new Newtonsoft.Json.Serialization.DefaultContractResolver();
                     });
 
                 services.AddSwaggerGen(options =>


### PR DESCRIPTION
Add GetTickPrices endpoint - returns the best tickprices (lowest ask and highest bid) from each orderbook with a particular dateTime range.  Repeating tickprices (same best ask and bid from consequent orderbooks) are returned just once - with the timestamp of their first occurrence. We iterate through all orderbooks for the period, pick each best ask and bid and add it ti the result.