### PR TITLE
Feature lwdev 6271 bitfinex add symbols ad filter config

### DIFF
--- a/src/Lykke.ExternalExchangesApi/Exchanges/Bitfinex/RestClient/IBitfinexApi.cs
+++ b/src/Lykke.ExternalExchangesApi/Exchanges/Bitfinex/RestClient/IBitfinexApi.cs
@@ -13,5 +13,6 @@ namespace Lykke.ExternalExchangesApi.Exchanges.Bitfinex.RestClient
         Task<object> GetBalances(CancellationToken cancellationToken = default);
         Task<object> GetMarginInformation(CancellationToken cancellationToken = default);
         Task<object> GetActivePositions(CancellationToken cancellationToken = default);
+        Task<object> GetAllSymbols(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Lykke.ExternalExchangesApi/Exchanges/Bitfinex/RestClient/Model/BitfinexGetBase.cs
+++ b/src/Lykke.ExternalExchangesApi/Exchanges/Bitfinex/RestClient/Model/BitfinexGetBase.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Lykke.ExternalExchangesApi.Exchanges.Bitfinex.RestClient.Model
+{
+    public class BitfinexGetBase
+    {
+        [JsonProperty("request")]
+        public string Request { get; set; }
+    }
+}

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexExecutionHarvester.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexExecutionHarvester.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Common;
 using Common.Log;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model;
 using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Trading;
@@ -26,7 +26,7 @@ namespace TradingBot.Exchanges.Concrete.BitMEX
             _socketSubscriber = socketSubscriber;
             _tradeHandler = tradeHandler;
             _log = log.CreateComponentScope(nameof(BitMexExecutionHarvester));
-            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols);
+            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols, configuration);
         }
 
         private async Task HandleExecutionResponseAsync(TableResponse table)

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexModelConverter.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexModelConverter.cs
@@ -1,18 +1,18 @@
-﻿using System;
+﻿using Lykke.ExternalExchangesApi.Exchanges.BitMex.AutorestClient.Models;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Newtonsoft.Json;
-using Lykke.ExternalExchangesApi.Exchanges.BitMex.AutorestClient.Models;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Models.Api;
 using TradingBot.Trading;
 using Instrument = TradingBot.Trading.Instrument;
 using Order = Lykke.ExternalExchangesApi.Exchanges.BitMex.AutorestClient.Models.Order;
-using Position = Lykke.ExternalExchangesApi.Exchanges.BitMex.AutorestClient.Models.Position;
 using OrdStatus = Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model.OrdStatus;
-using Side = Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model.Side;
+using Position = Lykke.ExternalExchangesApi.Exchanges.BitMex.AutorestClient.Models.Position;
 using RowItem = Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model.RowItem;
+using Side = Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model.Side;
 using TradeType = TradingBot.Trading.TradeType;
 
 namespace TradingBot.Exchanges.Concrete.BitMEX
@@ -21,7 +21,7 @@ namespace TradingBot.Exchanges.Concrete.BitMEX
     {
         private const decimal SatoshiRate = 100000000;
 
-        public BitMexModelConverter(IReadOnlyCollection<CurrencySymbol> currencySymbols) : base(currencySymbols, BitMexExchange.Name)
+        public BitMexModelConverter(IReadOnlyCollection<CurrencySymbol> currencySymbols, BitMexExchangeConfiguration config) : base(currencySymbols, BitMexExchange.Name, config.UseSupportedCurrencySymbolsAsFilter)
         {
 
         }

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexOrderHarvester.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexOrderHarvester.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Common;
 using Common.Log;
-using Newtonsoft.Json;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Trading;
@@ -30,7 +30,7 @@ namespace TradingBot.Exchanges.Concrete.BitMEX
             _socketSubscriber = socketSubscriber;
             _log = log;
             _tradeHandler = tradeHandler;
-            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols);
+            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols, configuration);
         }
 
 

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexPriceHarvester.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/BitMEX/BitMexPriceHarvester.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Common;
 using Common.Log;
-using Newtonsoft.Json;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient;
 using Lykke.ExternalExchangesApi.Exchanges.BitMex.WebSocketClient.Model;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Trading;
@@ -29,7 +29,7 @@ namespace TradingBot.Exchanges.Concrete.BitMEX
             _socketSubscriber = socketSubscriber;
             _log = log;
             _tickPriceHandler = tickPriceHandler;
-            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols);
+            _mapper = new BitMexModelConverter(configuration.SupportedCurrencySymbols, configuration);
         }
 
         private async Task HandleResponseAsync(TableResponse table)

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Bitfinex/BitfinexModelConverter.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Bitfinex/BitfinexModelConverter.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.WebSocketClient.Model;
+using System;
 using System.Globalization;
-using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.WebSocketClient.Model;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Trading;
@@ -10,7 +10,7 @@ namespace TradingBot.Exchanges.Concrete.Bitfinex
     internal sealed class BitfinexModelConverter : ExchangeConverters
     {
 
-        public BitfinexModelConverter(BitfinexExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, BitfinexExchange.Name)
+        public BitfinexModelConverter(BitfinexExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, BitfinexExchange.Name, configuration.UseSupportedCurrencySymbolsAsFilter)
         {
         }
 

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Bitfinex/BitfinexOrderBooksHarvester.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Bitfinex/BitfinexOrderBooksHarvester.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using Common.Log;
+using Lykke.ExternalExchangesApi.Exceptions;
+using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.RestClient;
+using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.RestClient.Model;
+using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.WebSocketClient.Model;
+using Lykke.ExternalExchangesApi.Shared;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Common.Log;
-using Lykke.ExternalExchangesApi.Exchanges.Bitfinex.WebSocketClient.Model;
-using Lykke.ExternalExchangesApi.Shared;
 using TradingBot.Communications;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Handlers;
@@ -18,6 +21,7 @@ namespace TradingBot.Exchanges.Concrete.Bitfinex
         private readonly BitfinexExchangeConfiguration _configuration;
         private readonly Dictionary<long, Channel> _channels;
         private readonly IHandler<TickPrice> _tickPriceHandler;
+        private readonly IBitfinexApi _exchangeApi;
 
         public BitfinexOrderBooksHarvester(BitfinexExchangeConfiguration configuration,
             OrderBookSnapshotsRepository orderBookSnapshotsRepository,
@@ -30,6 +34,11 @@ namespace TradingBot.Exchanges.Concrete.Bitfinex
             _configuration = configuration;
             _channels = new Dictionary<long, Channel>();
             _tickPriceHandler = tickPriceHandler;
+            var credenitals = new BitfinexServiceClientCredentials(configuration.ApiKey, configuration.ApiSecret);
+            _exchangeApi = new BitfinexApi(credenitals)
+            {
+                BaseUri = new Uri(configuration.EndpointUrl)
+            };
         }
 
 
@@ -67,18 +76,41 @@ namespace TradingBot.Exchanges.Concrete.Bitfinex
                 TickerResponse.Parse(json) ??
                 OrderBookSnapshotResponse.Parse(json) ??
                 (dynamic)OrderBookUpdateResponse.Parse(json) ??
-                HeartbeatResponse.Parse(json);
+                HeartbeatResponse.Parse(json); 
             return result;
         }
 
         private async Task Subscribe()
         {
-            var instruments = _configuration.SupportedCurrencySymbols
-                .Select(s => s.ExchangeSymbol)
-                .ToList();
+            var instrumentsToSubscribeFor = _configuration.SupportedCurrencySymbols?
+                                  .Select(s => s.ExchangeSymbol)
+                                  .ToList() ??  new List<string>();
 
-            await SubscribeToOrderBookAsync(instruments);
-            await SubscribeToTickerAsync(instruments);
+            if (_configuration.UseSupportedCurrencySymbolsAsFilter == false)
+            {
+                var response = await _exchangeApi.GetAllSymbols(CancellationToken);
+                if (response is Error error)
+                {
+                    throw new ApiException(error.Message);
+                }
+                var instrumentsFromExchange = ((IReadOnlyList<string>)response).Select(i=>i.ToUpper()).ToList();
+
+                foreach (var exchInstr in instrumentsFromExchange)
+                {
+                    if (!instrumentsToSubscribeFor.Contains(exchInstr))
+                    {
+                        instrumentsToSubscribeFor.Add(exchInstr);
+                    }
+                }
+            }
+
+            if (!instrumentsToSubscribeFor.Any())
+            {
+                await Log.WriteWarningAsync(nameof(Subscribe), "Subscribing for orderbooks", "Instruments list is empty - its either not set in config and UseSupportedCurrencySymbolsAsFilter is set to true or exchange returned empty symbols list. No symbols to subscribe for.");
+            }
+
+            await SubscribeToOrderBookAsync(instrumentsToSubscribeFor);
+            await SubscribeToTickerAsync(instrumentsToSubscribeFor);
         }
 
         private async Task SubscribeToOrderBookAsync(IEnumerable<string> instruments)

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxConverters.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxConverters.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient.Entities;
+using System;
 using System.Collections.Generic;
-using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient.Entities;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Trading;
@@ -11,7 +11,7 @@ namespace TradingBot.Exchanges.Concrete.GDAX
     internal class GdaxConverters: ExchangeConverters
     {
         public GdaxConverters(IReadOnlyCollection<CurrencySymbol> currencySymbols, 
-            string exchangeName): base(currencySymbols, exchangeName)
+            string exchangeName, GdaxExchangeConfiguration config): base(currencySymbols, exchangeName, config.UseSupportedCurrencySymbolsAsFilter)
         {
 
         }

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxExchange.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxExchange.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Common.Log;
-using TradingBot.Communications;
+﻿using Common.Log;
 using Lykke.ExternalExchangesApi.Exceptions;
 using Lykke.ExternalExchangesApi.Exchanges.Abstractions.Models;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient.Entities;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.WssClient;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.WssClient.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using TradingBot.Communications;
 using TradingBot.Exchanges.Abstractions;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
@@ -40,7 +40,7 @@ namespace TradingBot.Exchanges.Concrete.GDAX
             : base(Name, configuration, translatedSignalsRepository, log)
         {
             _configuration = configuration;
-            _converters = new GdaxConverters(configuration.SupportedCurrencySymbols, Name);
+            _converters = new GdaxConverters(configuration.SupportedCurrencySymbols, Name, configuration);
 
             _orderBooksHarvester = orderBookHarvester;
             _tickPriceHandler = tickPriceHandler;

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxOrderBooksHarvester.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/GDAX/GdaxOrderBooksHarvester.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Common.Log;
-using TradingBot.Communications;
-using TradingBot.Exchanges.Concrete.GDAX.Entities;
+﻿using Common.Log;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.RestClient.Entities;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.WssClient;
 using Lykke.ExternalExchangesApi.Exchanges.GDAX.WssClient.Entities;
 using Lykke.ExternalExchangesApi.Helpers;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TradingBot.Communications;
+using TradingBot.Exchanges.Concrete.GDAX.Entities;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
@@ -40,7 +40,7 @@ namespace TradingBot.Exchanges.Concrete.GDAX
             _websocketApi = CreateWebSocketsApiClient();
             _restApi = CreateRestApiClient();
             _converters = new GdaxConverters(_configuration.SupportedCurrencySymbols,
-                ExchangeName);
+                ExchangeName, configuration);
         }
 
         protected override async Task MessageLoopImpl()

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmModelConverter.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Icm/IcmModelConverter.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using QuickFix.Fields;
+using QuickFix.FIX44;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuickFix.Fields;
-using QuickFix.FIX44;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Models.Api;
@@ -19,7 +19,7 @@ namespace TradingBot.Exchanges.Concrete.Icm
     {
         private readonly IcmExchangeConfiguration _configuration;
 
-        public IcmModelConverter(IcmExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, IcmExchange.Name)
+        public IcmModelConverter(IcmExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, IcmExchange.Name, configuration.UseSupportedCurrencySymbolsAsFilter)
         {
             _configuration = configuration;
         }

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Jfd/JfdModelConverter.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Jfd/JfdModelConverter.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using QuickFix.Fields;
+using QuickFix.FIX44;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using QuickFix.Fields;
-using QuickFix.FIX44;
 using TradingBot.Exchanges.Concrete.Shared;
 using TradingBot.Infrastructure.Configuration;
 using TradingBot.Models.Api;
@@ -29,7 +29,7 @@ namespace TradingBot.Exchanges.Concrete.Jfd
             public const int OzEquity = 8886;
         }
 
-        public JfdModelConverter(JfdExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, JfdExchange.Name)
+        public JfdModelConverter(JfdExchangeConfiguration configuration) : base(configuration.SupportedCurrencySymbols, JfdExchange.Name, configuration.UseSupportedCurrencySymbolsAsFilter)
         {
             _configuration = configuration;
         }

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Shared/CurrencySymbolConverter.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Shared/CurrencySymbolConverter.cs
@@ -10,35 +10,35 @@ namespace TradingBot.Exchanges.Concrete.Shared
     {
         private readonly IReadOnlyCollection<CurrencySymbol> _currencySymbols;
         private readonly string _exchangeName;
+        private readonly bool _useSupportedCurrencySymbolsAsFilter;
 
         public ExchangeConverters(IReadOnlyCollection<CurrencySymbol> currencySymbols, 
-            string exchangeName)
+            string exchangeName, bool useSupportedCurrencySymbolsAsFilter)
         {
             _currencySymbols = currencySymbols;
+            _useSupportedCurrencySymbolsAsFilter = useSupportedCurrencySymbolsAsFilter;
             _exchangeName = exchangeName;
         }
 
         public string LykkeSymbolToExchangeSymbol(string lykkeSymbol)
         {
-            var foundSymbol = _currencySymbols
-                .FirstOrDefault(s => s.LykkeSymbol == lykkeSymbol);
-            if (foundSymbol == null)
+            var foundSymbol = _currencySymbols.FirstOrDefault(s => s.LykkeSymbol == lykkeSymbol);
+            if (foundSymbol == null && _useSupportedCurrencySymbolsAsFilter)
             {
                 throw new ArgumentException($"Symbol {lykkeSymbol} is not mapped to {_exchangeName} value");
             }
-            return foundSymbol.ExchangeSymbol;
+            return foundSymbol?.ExchangeSymbol ?? lykkeSymbol;
         }
 
         public Instrument ExchangeSymbolToLykkeInstrument(string exchangeSymbol)
         {
-            var foundSymbol = _currencySymbols
-               .FirstOrDefault(s => s.ExchangeSymbol == exchangeSymbol);
-            if (foundSymbol == null)
+            var foundSymbol = _currencySymbols.FirstOrDefault(s => s.ExchangeSymbol == exchangeSymbol);
+            if (foundSymbol == null && _useSupportedCurrencySymbolsAsFilter)
             {
                 throw new ArgumentException(
                     $"Symbol {exchangeSymbol} in {_exchangeName} is not mapped to lykke value");
             }
-            return new Instrument(_exchangeName, foundSymbol.LykkeSymbol);
+            return new Instrument(_exchangeName, foundSymbol?.LykkeSymbol ?? exchangeSymbol);
         }
     }
 }

--- a/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Shared/OrderBooksHarvesterBase.cs
+++ b/src/Lykke.Service.ExchangeConnector/Exchanges/Concrete/Shared/OrderBooksHarvesterBase.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Common.Log;
+using Polly;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Common.Log;
-using Polly;
 using TradingBot.Communications;
 using TradingBot.Handlers;
 using TradingBot.Infrastructure.Configuration;
@@ -53,7 +53,7 @@ namespace TradingBot.Exchanges.Concrete.Shared
             Log = log.CreateComponentScope(GetType().Name);
 
             _converters = new ExchangeConverters(exchangeConfiguration.SupportedCurrencySymbols,
-                string.Empty);
+                string.Empty, exchangeConfiguration.UseSupportedCurrencySymbolsAsFilter);
 
             _orderBookSnapshots = new ConcurrentDictionary<string, OrderBookSnapshot>();
             _cancellationTokenSource = new CancellationTokenSource();

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitMexExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitMexExchangeConfiguration.cs
@@ -18,7 +18,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public string ApiKey { get; set; }
 

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitfinexExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitfinexExchangeConfiguration.cs
@@ -18,7 +18,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public string ApiKey { get; set; }
 

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitstampConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/BitstampConfiguration.cs
@@ -14,7 +14,7 @@ namespace TradingBot.Infrastructure.Configuration
         public bool PubQuotesToRabbit { get; set; }
         public double InitialRating { get; set; }
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
         public string ApplicationKey { get; set; }
 
         public IReadOnlyCollection<CurrencySymbol> SupportedCurrencySymbols { get; set; }

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/GdaxExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/GdaxExchangeConfiguration.cs
@@ -12,7 +12,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public bool Enabled { get; set; }
 

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/HistoricalDataConfig.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/HistoricalDataConfig.cs
@@ -14,7 +14,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public string BaseDirectory { get; set; }
         

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/IExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/IExchangeConfiguration.cs
@@ -17,7 +17,7 @@ namespace TradingBot.Infrastructure.Configuration
         /// true or null - provide only this instrument with mapping name
         /// false - provide all instrument and mapping name use this array
         /// </summary>
-        bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         IReadOnlyCollection<CurrencySymbol> SupportedCurrencySymbols { get; }
     }

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/IcmExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/IcmExchangeConfiguration.cs
@@ -21,7 +21,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public bool SocketConnection { get; set; }
 

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/JfdExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/JfdExchangeConfiguration.cs
@@ -21,7 +21,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         IReadOnlyCollection<CurrencySymbol> IExchangeConfiguration.SupportedCurrencySymbols => SupportedCurrencySymbols;
 

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/KrakenConfig.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/KrakenConfig.cs
@@ -18,7 +18,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public string ApiKey { get; set; }
         

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/LykkeExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/LykkeExchangeConfiguration.cs
@@ -17,7 +17,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public string ApiKey { get; set; }
         

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/OandaConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/OandaConfiguration.cs
@@ -18,7 +18,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public IReadOnlyCollection<CurrencySymbol> SupportedCurrencySymbols { get; set; }
     }

--- a/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/StubExchangeConfiguration.cs
+++ b/src/Lykke.Service.ExchangeConnector/Infrastructure/Configuration/StubExchangeConfiguration.cs
@@ -18,7 +18,7 @@ namespace TradingBot.Infrastructure.Configuration
         public double InitialRating { get; set; }
 
         [Lykke.SettingsReader.Attributes.Optional]
-        public bool? UseSupportedCurrencySymbolsAsFilter { get; set; }
+        public bool UseSupportedCurrencySymbolsAsFilter { get; set; }
 
         public int PricesIntervalInMilliseconds { get; set; }
         


### PR DESCRIPTION
Bitfinex UseSupportedCurrencySymbolsAsFilter enabled. The option has been added to the base symbol converter class  - ExchangeConverters, which basically affects other exchangess too, but as its default value is true, the logic for mapping symbols had not changed.